### PR TITLE
Improve "undo expand" keybinding example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and so on...
     "key": "ctrl+w","command": "expand_region", "when": "editorTextFocus"
 },
 {
-    "key": "ctrl+shift+w","command": "undo_expand_region", "when": "editorTextFocus"
+    "key": "ctrl+shift+w","command": "undo_expand_region", "when": "editorTextFocus && editorHasSelection"
 }
 ```
 ## development


### PR DESCRIPTION
This avoids weird behaviors if undoing a selection after moving out from a previous expansion session.